### PR TITLE
Upgrade Unity Ads SDK Into 4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.13
+
+* Switched unity ads version to 4.10.0
+
 ## 0.3.12
 
 * Switched unity ads version to 4.9.3

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,5 +39,5 @@ android {
 }
 
 dependencies {
-    implementation group: 'com.unity3d.ads', name: 'unity-ads', version: '4.9.3'
+    implementation group: 'com.unity3d.ads', name: 'unity-ads', version: '4.10.0'
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - Flutter (1.0.0)
   - unity_ads_plugin (0.0.1):
     - Flutter
-    - UnityAds (= 4.9.3)
-  - UnityAds (4.9.3)
+    - UnityAds (= 4.10.0)
+  - UnityAds (4.10.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,9 +21,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  unity_ads_plugin: 73033b430fc9bd3f50f791297d6f350394256c6d
-  UnityAds: c503b06232a002ff6dc9677f4e32c6e1ae286232
+  unity_ads_plugin: 07bad0afdaf2e44f71da0ec1a4cfd0817fb9c6cb
+  UnityAds: 5601f6397b0e02ed3ed6ee92827f5177a523aab6
 
 PODFILE CHECKSUM: 7c7417cb9697dbd1c138ccc61d551e103492b177
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.15.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				EAEB96C04ACE9A04B9908FFB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -250,6 +251,23 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
+		EAEB96C04ACE9A04B9908FFB /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -347,7 +365,10 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -479,7 +500,10 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -506,7 +530,10 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -198,7 +198,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.12"
+    version: "0.3.13"
   vector_math:
     dependency: transitive
     description:

--- a/ios/unity_ads_plugin.podspec
+++ b/ios/unity_ads_plugin.podspec
@@ -17,7 +17,7 @@ Flutter unity ads plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
-  s.dependency 'UnityAds', '4.9.3'
+  s.dependency 'UnityAds', '4.10.0'
 
   # Flutter.framework does not contain a i386 slice.
   # s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: unity_ads_plugin
 description: Unity Ads plugin for Flutter Applications. This plugin is able to display Unity Banner Ads and Unity Video Ads.
-version: 0.3.12
+version: 0.3.13
 homepage: https://github.com/pavelzaichyk/flutter_unity_ads
 repository: https://github.com/pavelzaichyk/flutter_unity_ads
 funding:


### PR DESCRIPTION
This pull request updates the Unity Ads SDK to version 4.10.0 Which Currently the Latest Version.

I Also Already Increase the Version Of the Package Into 0.3.13 so it will be ready to be released